### PR TITLE
Feature/100925808/loading indicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml
 .repl
 .nrepl-port
 *.swp
+.DS_Store

--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,6 @@
   </head>
   <body>
     <pdf-viewer src="fixtures/presentation.pdf" height="480" width="640" workerSrc="pdf-viewer.worker.js"></pdf-viewer>
-
     <script src="pdf-viewer.js" type="text/javascript"></script>
   </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,7 @@
 
   </head>
   <body>
-    <pdf-viewer src="fixtures/presentation.pdf" height="480" width="640" workerSrc="pdf-viewer.worker.js"></pdf-viewer>
+    <pdf-viewer src="fixtures/presentation.pdf" width="640" workerSrc="pdf-viewer.worker.js"></pdf-viewer>
     <script src="pdf-viewer.js" type="text/javascript"></script>
   </body>
 </html>

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -12,3 +12,9 @@ pdf-viewer #om-root .navigation {
 pdf-viewer #om-root .navigation .navButtons {
   float: right;
 }
+
+.progress {
+  margin: 0 auto;
+  display: block;
+  width: 100px;
+}

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -7,7 +7,6 @@
   <body>
     <pdf-viewer workerSrc="/js/compiled/out/pdf.worker.js" src="fixtures/presentation.pdf" width="640"></pdf-viewer>
 
-    </div>
     <script src="js/compiled/pdf-viewer.js" type="text/javascript"></script>
   </body>
 </html>

--- a/src/pdf-viewer/core.cljs
+++ b/src/pdf-viewer/core.cljs
@@ -96,12 +96,12 @@
       (let [loadingTask (.getDocument js/PDFJS (:pdf_url @app-state))]
 
         (aset loadingTask "onProgress" (fn [progress] (om/update! cursor
-                                                             [:progress :loading 0]
-                                                             (/ (.-loaded progress) (.-total progress)))))
+                                                                  [:progress :loading 0]
+                                                                  (/ (.-loaded progress) (.-total progress)))))
         (.then loadingTask (fn [pdf]
-                 (swap! app-state assoc :pdf pdf)
-                 (swap! app-state update-in [:navigation :page_count 0] #(.-numPages pdf))
-                 (render-page)))))
+                             (swap! app-state assoc :pdf pdf)
+                             (swap! app-state update-in [:navigation :page_count 0] #(.-numPages pdf))
+                             (render-page)))))
     om/IRender
     (render [this]
       (dom/canvas #js {:width (:pdf_width @app-state)}))))


### PR DESCRIPTION
When loading a huge PDF, the network latency made the viewer look really bad in that it showed "1 of 0" pages and was just empty. To circumvent, `pdf-viewer` now shows progress while loading the PDF:

<img width="665" alt="firefox_developer_edition" src="https://cloud.githubusercontent.com/assets/505721/9290728/7ab689a0-439d-11e5-932e-3f4e2bc8c2e2.png">

In the test files, rendering the actual first page did not take any noticable time anymore.

This (as well as the rest of the component) could need some design love. This is intentionally an easy implementation. I'd say @lab27 could take a stab at the whole component. I'll write down a `discuss` story for that.
